### PR TITLE
fix: eliminate flash of unstyled content (FOUC)

### DIFF
--- a/apps/web/app/__root.tsx
+++ b/apps/web/app/__root.tsx
@@ -53,6 +53,11 @@ export const Route = createRootRoute({
     ],
     links: [
       {
+        rel: 'preload',
+        href: appCss,
+        as: 'style',
+      },
+      {
         rel: 'stylesheet',
         href: appCss,
       },
@@ -71,7 +76,7 @@ function RootLayout() {
   useEffect(() => setMounted(true), []);
 
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" className="dark" suppressHydrationWarning>
       <head>
         <HeadContent />
       </head>

--- a/apps/web/components/ui/sonner.tsx
+++ b/apps/web/components/ui/sonner.tsx
@@ -1,4 +1,4 @@
-import { useTheme } from "next-themes"
+import { useTheme } from "tanstack-theme-kit"
 import { Toaster as Sonner, type ToasterProps } from "sonner"
 import { HugeiconsIcon } from "@hugeicons/react"
 import { CheckmarkCircle02Icon, InformationCircleIcon, Alert02Icon, MultiplicationSignCircleIcon, Loading03Icon } from "@hugeicons/core-free-icons"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,7 +37,6 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.577.0",
-    "next-themes": "^0.4.6",
     "nitro": "^3.0.1-alpha.1",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/bun.lock
+++ b/bun.lock
@@ -132,7 +132,6 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "lucide-react": "^0.577.0",
-        "next-themes": "^0.4.6",
         "nitro": "^3.0.1-alpha.1",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -2408,8 +2407,6 @@
     "nested-error-stacks": ["nested-error-stacks@2.0.1", "", {}, "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A=="],
 
     "next": ["next@15.5.12", "", { "dependencies": { "@next/env": "15.5.12", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.12", "@next/swc-darwin-x64": "15.5.12", "@next/swc-linux-arm64-gnu": "15.5.12", "@next/swc-linux-arm64-musl": "15.5.12", "@next/swc-linux-x64-gnu": "15.5.12", "@next/swc-linux-x64-musl": "15.5.12", "@next/swc-win32-arm64-msvc": "15.5.12", "@next/swc-win32-x64-msvc": "15.5.12", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-Fi/wQ4Etlrn60rz78bebG1i1SR20QxvV8tVp6iJspjLUSHcZoeUXCt+vmWoEcza85ElZzExK/jJ/F6SvtGktjA=="],
-
-    "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
     "nf3": ["nf3@0.3.10", "", {}, "sha512-UlqmHkZiHGgSkRj17yrOXEsSu5ECvtlJ3Xm1W5WsWrTKgu9m7OjrMZh9H/ME2LcWrTlMD0/vmmNVpyBG4yRdGg=="],
 


### PR DESCRIPTION
## Summary
- Set `class="dark"` on `<html>` during SSR so the default theme styles apply from first paint
- Add `<link rel="preload">` for the CSS bundle so the browser fetches it at highest priority
- Fix `Toaster` component using `useTheme` from `next-themes` (no provider) — switched to `tanstack-theme-kit` (actual provider in the tree)
- Remove unused `next-themes` dependency

## Test plan
- [ ] Deploy to production and verify no flash of white/unstyled content on page load
- [ ] Verify dark mode is applied immediately on first paint
- [ ] Verify toast notifications respect the correct theme
- [ ] Toggle theme to light mode — verify it still works after hydration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dark mode styling is now available and enabled throughout the application.

* **Style**
  * CSS resource loading has been optimized with preload enhancements for better performance.
  * Application theme handling system has been updated and refined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->